### PR TITLE
Add 'PathInProject' property to 'ItemAttributes' class.

### DIFF
--- a/datamanagement/source/model/itemAttributes.ts
+++ b/datamanagement/source/model/itemAttributes.ts
@@ -87,5 +87,11 @@ export interface ItemAttributes {
      * @memberof ItemAttributes
      */
     'extension': ItemExtensionWithSchemaLink;
+    /**
+     * The relative path of the item starting from project’s root folder.
+     * @type {string}
+     * @memberof ItemAttributes
+     */
+    'pathInProject'?: string;
 }
 


### PR DESCRIPTION
# Reason
- Match pull request made to APS .NET SDK: [#208](https://github.com/autodesk-platform-services/aps-sdk-net/pull/208), [#211](https://github.com/autodesk-platform-services/aps-sdk-net/pull/211).

# Changes
- Added 'PathInProject' property to the [ItemAttributes](https://github.com/autodesk-platform-services/aps-sdk-node/blob/main/datamanagement/source/model/itemAttributes.ts) class.
  - 'PathInProject' property exists in the [response documentation](https://aps.autodesk.com/en/docs/data/v2/reference/http/projects-project_id-items-item_id-GET/#body-structure-200).
  - 'PathInProject' property exists in the response data (sample data from Postman request).
    ``` json
    {
      "jsonapi": { },
      "links": { },
      "data": {
        "type": "items",
        "id": "urn:adsk.wipprod:dm.lineage:123ABC",
        "attributes": {
          "displayName": "TestFile.xlsx",
          "createTime": "2025-05-08T00:00:00.0000000Z",
          "createUserId": "456DEF",
          "createUserName": "Sample User",
          "lastModifiedTime": "2025-05-08T00:00:00.0000000Z",
          "lastModifiedUserId": "456DEF",
          "lastModifiedUserName": "Sample User",
          "hidden": false,
          "reserved": false,
          "extension": { },
          "pathInProject": "/Project Files/Test Folder"
        },
        "links": { },
        "relationships": { }
      },
      "included": [ ]
    }
    ```

# Reference Methods:
- [itemsApi/getItem()](https://github.com/autodesk-platform-services/aps-sdk-node/blob/062ffb77c969fa5201c33e3e69610a605eeea6f5/datamanagement/source/api/itemsApi.ts#L138)
- [dataManagementClient/getItem()](https://github.com/autodesk-platform-services/aps-sdk-node/blob/062ffb77c969fa5201c33e3e69610a605eeea6f5/datamanagement/source/custom-code/dataManagementClient.ts#L752)